### PR TITLE
Fix PHP8 mandatory public visibility on wakeup method

### DIFF
--- a/years-ago-today.php
+++ b/years-ago-today.php
@@ -83,7 +83,7 @@ class c2c_YearsAgoToday {
 	 *
 	 * @since 1.2
 	 */
-	private function __wakeup() {}
+	public function __wakeup() {}
 
 	/**
 	 * Returns version of the plugin.


### PR DESCRIPTION
Hi there,
Here is a fix for PHP8 that requires a public visibility on `__wakeup` methods.
Have a nice day.