### PR TITLE
Fix  in strings is deprecated

### DIFF
--- a/years-ago-today.php
+++ b/years-ago-today.php
@@ -282,7 +282,7 @@ class c2c_YearsAgoToday {
 				// Only output the year once.
 				if ( $year != $this_year ) {
 					$year = $this_year;
-					$body .= "\n\n== ${year} ==\n";
+					$body .= "\n\n== $year ==\n";
 				}
 
 				$body .= '* ' . get_the_title() .  ' : ' . esc_url( get_permalink() ) . "\n";
@@ -413,7 +413,7 @@ class c2c_YearsAgoToday {
 				// Only output the year once.
 				if ( $year != $this_year ) {
 					$year = $this_year;
-					echo "<li class='years-ago-today-year'><h4>${year}</h4></li>\n";
+					echo "<li class='years-ago-today-year'><h4>$year</h4></li>\n";
 				}
 
 				the_title( '<li><a href="' . esc_url( get_permalink() ) . '">', '</a></li>' );


### PR DESCRIPTION
Hi there,
Just some quick update to get rid of PHP8.2 deprecated messages:
````
PHP message: PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in wp-content/plugins/years-ago-today/years-ago-today.php on line 285;
PHP message: PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead inwp-content/plugins/years-ago-today/years-ago-today.php on line 416
````
Have a nice day.