### PR TITLE
Fix cronjob not being installed

### DIFF
--- a/years-ago-today.php
+++ b/years-ago-today.php
@@ -42,7 +42,8 @@
 defined( 'ABSPATH' ) or die();
 
 if ( ! class_exists( 'c2c_YearsAgoToday' ) ) :
-
+register_activation_hook( __FILE__, array( 'c2c_YearsAgoToday', 'activate' ) );
+	
 class c2c_YearsAgoToday {
 
 	/**
@@ -105,7 +106,6 @@ class c2c_YearsAgoToday {
 			return false;
 		}
 
-		register_activation_hook( __FILE__, array( __CLASS__, 'activate' ) );
 		register_deactivation_hook( __FILE__, array( __CLASS__, 'deactivate' ) );
 
 		// Load textdomain.

--- a/years-ago-today.php
+++ b/years-ago-today.php
@@ -42,7 +42,6 @@
 defined( 'ABSPATH' ) or die();
 
 if ( ! class_exists( 'c2c_YearsAgoToday' ) ) :
-register_activation_hook( __FILE__, array( 'c2c_YearsAgoToday', 'activate' ) );
 	
 class c2c_YearsAgoToday {
 
@@ -603,6 +602,7 @@ class c2c_YearsAgoToday {
 } // end c2c_YearsAgoToday
 
 add_action( 'plugins_loaded', array( 'c2c_YearsAgoToday', 'init' ) );
+register_activation_hook( __FILE__, array( 'c2c_YearsAgoToday', 'activate' ) );
 c2c_YearsAgoToday::cron_init();
 
 endif; // end if !class_exists()

--- a/years-ago-today.php
+++ b/years-ago-today.php
@@ -42,7 +42,7 @@
 defined( 'ABSPATH' ) or die();
 
 if ( ! class_exists( 'c2c_YearsAgoToday' ) ) :
-	
+
 class c2c_YearsAgoToday {
 
 	/**


### PR DESCRIPTION
I have been having trouble getting the daily e-mail, it turned out, the cronjob was not installed. I tried deactivating and activating but it still wasn't installed.

It turns out that the `register_activation_hook` was not being called, because it is only installed when the `plugins_loaded` hook is called. This is not the case when activating plugins, thus the cronjob was never installed.

This moves the `register_activation_hook` to the top level so that it will now really be called when the plugin is activated.