### PR TITLE
Fix check for empty e-mail

### DIFF
--- a/years-ago-today.php
+++ b/years-ago-today.php
@@ -210,7 +210,7 @@ class c2c_YearsAgoToday {
 	 *
 	 * @since 1.2
 	 *
-	 * @return string
+	 * @return array
 	 */
 	public static function get_email_body() {
 		// Get the list of posts from years ago.
@@ -399,7 +399,7 @@ class c2c_YearsAgoToday {
 		$body    = self::get_email_body();
 
 		// If no subject or body for the email, then there's nothing else to do.
-		if ( ! $subject || ! $body ) {
+		if ( ! $subject || ! $body['text'] ) {
 			return;
 		}
 		$headers = array();


### PR DESCRIPTION
In #5, I broke skipping empty e-mails because the `$body` check is always true because it's now an array. This PR fixes that. Sorry!